### PR TITLE
Enable cgo in build step of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 COPY . .
 # get ssl certs to copy into scratch image, as it won't have them by default.
 RUN apk update && apk add --no-cache git ca-certificates && update-ca-certificates
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o /usr/local/bin/crossposting-service ./cmd/crossposting-service
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -v -o /usr/local/bin/crossposting-service ./cmd/crossposting-service
 
 
 FROM scratch as app


### PR DESCRIPTION
our program uses go-sqlite3, which requires cgo.