### PR TITLE
Fix subscriptions slow to update

### DIFF
--- a/service/adapters/relay_event_downloader.go
+++ b/service/adapters/relay_event_downloader.go
@@ -12,9 +12,6 @@ import (
 
 const (
 	storeMetricsEvery = 30 * time.Second
-
-	reconnectAfter           = 1 * time.Minute
-	manageSubscriptionsEvery = 10 * time.Second
 )
 
 type RelayEventDownloader struct {


### PR DESCRIPTION
The problem was that we only sent out info about new subs to relays every 10 seconds. So in the worst scenario of creating subscriptions sequentially like with purple pages we had to wait 10 seconds per subscription.

I am very tired but I think there is an invariant in this code that new channel is only created when there is no need for an update therefore we won't end up in the situation where channel is closed but no update happens? We can therefore drop time.After completely.