### PR TITLE
Treat "malformed" contact events as no data

### DIFF
--- a/service/adapters/purple_pages.go
+++ b/service/adapters/purple_pages.go
@@ -176,7 +176,12 @@ func (p *PurplePages) getRelaysFromContacts(ctx context.Context, publicKey domai
 		case domain.EventKindContacts:
 			result, err := domain.GetRelaysFromContactsEvent(event)
 			if err != nil {
-				return nil, errors.Wrap(err, "error getting contacts from event")
+				p.logger.
+					Debug().
+					WithError(err).
+					WithField("eventContent", event.Content()).
+					Message("error extracting relays from contacts event")
+				return nil, errLookupFoundNoEvents
 			}
 			return result, nil
 		default:


### PR DESCRIPTION
The format of those events is not covered by a NIP and is a hack, for our use case we should just treat this as a "no data" scenario.