### PR TITLE
Remove code which supported events without certain fields

### DIFF
--- a/service/adapters/sqlite/publisher.go
+++ b/service/adapters/sqlite/publisher.go
@@ -48,7 +48,7 @@ type TweetCreatedEventTransport struct {
 	AccountID string         `json:"accountID"`
 	Tweet     TweetTransport `json:"tweet"`
 	Event     []byte         `json:"event"`
-	CreatedAt *time.Time     `json:"createdAt"`
+	CreatedAt time.Time      `json:"createdAt"`
 }
 
 type TweetTransport struct {

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -214,8 +214,8 @@ func (t TwitterAccountDetails) ProfileImageURL() string {
 type TweetCreatedEvent struct {
 	accountID accounts.AccountID
 	tweet     domain.Tweet
-	createdAt *time.Time
-	event     *domain.Event
+	createdAt time.Time
+	event     domain.Event
 }
 
 func NewTweetCreatedEvent(
@@ -223,20 +223,6 @@ func NewTweetCreatedEvent(
 	tweet domain.Tweet,
 	createdAt time.Time,
 	event domain.Event,
-) TweetCreatedEvent {
-	return TweetCreatedEvent{
-		accountID: accountID,
-		tweet:     tweet,
-		createdAt: &createdAt,
-		event:     &event,
-	}
-}
-
-func NewTweetCreatedEventFromHistory(
-	accountID accounts.AccountID,
-	tweet domain.Tweet,
-	createdAt *time.Time,
-	event *domain.Event,
 ) TweetCreatedEvent {
 	return TweetCreatedEvent{
 		accountID: accountID,
@@ -254,11 +240,11 @@ func (t TweetCreatedEvent) Tweet() domain.Tweet {
 	return t.tweet
 }
 
-func (t TweetCreatedEvent) CreatedAt() *time.Time {
+func (t TweetCreatedEvent) CreatedAt() time.Time {
 	return t.createdAt
 }
 
-func (t TweetCreatedEvent) Event() *domain.Event {
+func (t TweetCreatedEvent) Event() domain.Event {
 	return t.event
 }
 

--- a/service/app/handler_send_tweet_test.go
+++ b/service/app/handler_send_tweet_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/planetary-social/nos-crossposting-service/cmd/crossposting-service/di"
-	"github.com/planetary-social/nos-crossposting-service/internal"
 	"github.com/planetary-social/nos-crossposting-service/internal/fixtures"
 	"github.com/planetary-social/nos-crossposting-service/service/app"
 	"github.com/planetary-social/nos-crossposting-service/service/domain"
@@ -18,31 +17,15 @@ func TestSendTweetHandler_CorrectlyDropsOldEvents(t *testing.T) {
 		Name string
 
 		CurrentTime time.Time
-		Event       *domain.Event
+		Event       domain.Event
 
 		ShouldPostTweet bool
 	}{
 		{
-			Name: "old_events_are_dropped_after_a_week_since_code_change_passes",
-
-			CurrentTime: date(2023, time.November, 25),
-			Event:       nil,
-
-			ShouldPostTweet: false,
-		},
-		{
-			Name: "old_events_are_not_dropped_before_a_week_since_code_change_passes",
-
-			CurrentTime: date(2023, time.November, 23),
-			Event:       nil,
-
-			ShouldPostTweet: true,
-		},
-		{
 			Name: "new_events_are_dropped_after_a_week_since_they_were_created",
 
 			CurrentTime: date(2023, time.November, 28),
-			Event:       internal.Pointer(fixtures.SomeEventWithCreatedAt(date(2023, time.November, 20))),
+			Event:       fixtures.SomeEventWithCreatedAt(date(2023, time.November, 20)),
 
 			ShouldPostTweet: false,
 		},
@@ -50,7 +33,7 @@ func TestSendTweetHandler_CorrectlyDropsOldEvents(t *testing.T) {
 			Name: "new_events_are_not_dropped_before_a_week_since_they_were_created",
 
 			CurrentTime: date(2023, time.November, 27),
-			Event:       internal.Pointer(fixtures.SomeEventWithCreatedAt(date(2023, time.November, 20))),
+			Event:       fixtures.SomeEventWithCreatedAt(date(2023, time.November, 20)),
 
 			ShouldPostTweet: true,
 		},

--- a/service/ports/sqlitepubsub/tweet_created.go
+++ b/service/ports/sqlitepubsub/tweet_created.go
@@ -67,9 +67,9 @@ func (s *TweetCreatedEventSubscriber) handleMessage(ctx context.Context, msg *sq
 
 	tweet := domain.NewTweet(transport.Tweet.Text)
 
-	event, err := s.getEvent(transport)
+	event, err := domain.NewEventFromRaw(transport.Event)
 	if err != nil {
-		return errors.Wrap(err, "error getting the event from transport")
+		return errors.Wrap(err, "error loading the event")
 	}
 
 	cmd := app.NewSendTweet(accountID, tweet, event)
@@ -79,17 +79,4 @@ func (s *TweetCreatedEventSubscriber) handleMessage(ctx context.Context, msg *sq
 	}
 
 	return nil
-}
-
-func (s *TweetCreatedEventSubscriber) getEvent(transport sqlite.TweetCreatedEventTransport) (*domain.Event, error) {
-	if len(transport.Event) == 0 {
-		return nil, nil
-	}
-
-	event, err := domain.NewEventFromRaw(transport.Event)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating a domain event")
-	}
-
-	return &event, nil
 }

--- a/service/ports/sqlitepubsub/tweet_created_test.go
+++ b/service/ports/sqlitepubsub/tweet_created_test.go
@@ -27,15 +27,6 @@ func TestTweetCreatedEventSubscriber_CanHandleOldAndNewEvents(t *testing.T) {
 		ExpectedCommand app.SendTweet
 	}{
 		{
-			Name:    "old",
-			Payload: `{"accountID": "someAccountID", "tweet": {"text": "someTweetText"}}`,
-			ExpectedCommand: app.NewSendTweet(
-				accounts.MustNewAccountID("someAccountID"),
-				domain.NewTweet("someTweetText"),
-				nil,
-			),
-		},
-		{
 			Name: "new",
 			Payload: fmt.Sprintf(
 				`{"accountID": "someAccountID", "tweet": {"text": "someTweetText"}, "event": "%s", "createdAt": "%s"}`,
@@ -45,7 +36,7 @@ func TestTweetCreatedEventSubscriber_CanHandleOldAndNewEvents(t *testing.T) {
 			ExpectedCommand: app.NewSendTweet(
 				accounts.MustNewAccountID("someAccountID"),
 				domain.NewTweet("someTweetText"),
-				&event,
+				event,
 			),
 		},
 	}
@@ -76,11 +67,7 @@ func TestTweetCreatedEventSubscriber_CanHandleOldAndNewEvents(t *testing.T) {
 					call := calls[0]
 					assert.Equal(t, call.AccountID(), testCase.ExpectedCommand.AccountID())
 					assert.Equal(t, call.Tweet(), testCase.ExpectedCommand.Tweet())
-					if testCase.ExpectedCommand.Event() == nil {
-						require.Nil(t, call.Event())
-					} else {
-						assert.Equal(t, call.Event().Raw(), testCase.ExpectedCommand.Event().Raw())
-					}
+					assert.Equal(t, call.Event().Raw(), testCase.ExpectedCommand.Event().Raw())
 				}
 			}, 1*time.Second, 100*time.Millisecond)
 		})


### PR DESCRIPTION
Old "tweet created" events didn't have event and created at fields. Now that a week has passed they were all dropped.